### PR TITLE
Fix endless indexing loop when files fail to index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,11 +19,13 @@
         "ora": "^8.0.1",
         "pino": "^9.2.0",
         "tree-sitter": "^0.21.1",
+        "tree-sitter-ada": "github:briot/tree-sitter-ada",
         "tree-sitter-c": "^0.21.0",
+        "tree-sitter-c-sharp": "^0.20.0",
         "tree-sitter-cpp": "^0.21.0",
         "tree-sitter-python": "^0.21.0",
         "tree-sitter-typescript": "^0.21.1",
-        "typescript": "^5.4.5",
+        "typescript": "^5.9.3",
         "vectra": "^0.11.1",
         "ws": "^8.18.0",
         "yargs": "^17.7.2",
@@ -38,7 +40,6 @@
         "@types/inquirer": "^8.2.10",
         "@types/node": "^20.14.2",
         "@types/supertest": "^6.0.2",
-
         "@types/yargs": "^17.0.32",
         "@typescript-eslint/eslint-plugin": "^8.39.0",
         "@typescript-eslint/parser": "^8.39.0",
@@ -46,7 +47,6 @@
         "pino-pretty": "^11.2.1",
         "rimraf": "^5.0.7",
         "supertest": "^7.0.0",
-
         "ts-node": "^10.9.2",
         "typescript-eslint": "^8.39.0",
         "vitest": "^3.2.4"
@@ -1167,7 +1167,6 @@
       "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
       "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="
     },
-
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.17.3",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.3.tgz",
@@ -1213,7 +1212,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1249,7 +1247,6 @@
         "node": ">= 8"
       }
     },
-
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
@@ -1260,7 +1257,6 @@
         "@noble/hashes": "^1.1.5"
       }
     },
-
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1580,7 +1576,6 @@
       "dev": true,
       "license": "MIT"
     },
-
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1615,7 +1610,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
-
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -1623,7 +1617,6 @@
       "dev": true,
       "license": "MIT"
     },
-
     "node_modules/@types/node": {
       "version": "20.19.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
@@ -1641,7 +1634,6 @@
         "form-data": "^4.0.4"
       }
     },
-
     "node_modules/@types/superagent": {
       "version": "8.1.9",
       "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
@@ -1666,7 +1658,6 @@
         "@types/superagent": "^8.1.0"
       }
     },
-
     "node_modules/@types/through": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.33.tgz",
@@ -2043,7 +2034,6 @@
         "node": ">=6.5"
       }
     },
-
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -2078,7 +2068,6 @@
         "node": ">= 0.6"
       }
     },
-
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2186,7 +2175,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
-
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -2194,7 +2182,6 @@
       "dev": true,
       "license": "MIT"
     },
-
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2253,7 +2240,6 @@
         }
       ]
     },
-
     "node_modules/body-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -2274,7 +2260,6 @@
         "node": ">=18"
       }
     },
-
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -2325,7 +2310,6 @@
         "ieee754": "^1.2.1"
       }
     },
-
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -2335,7 +2319,6 @@
         "node": ">= 0.8"
       }
     },
-
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2355,6 +2338,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -2529,7 +2528,6 @@
         "node": ">= 0.8"
       }
     },
-
     "node_modules/component-emitter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
@@ -2540,14 +2538,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
-
     "node_modules/content-disposition": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
@@ -2607,7 +2603,6 @@
         "node": ">= 0.10"
       }
     },
-
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -2662,7 +2657,6 @@
         "node": "*"
       }
     },
-
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -2680,7 +2674,6 @@
         }
       }
     },
-
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -2704,7 +2697,6 @@
         "node": ">=0.4.0"
       }
     },
-
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2725,7 +2717,6 @@
         "wrappy": "1"
       }
     },
-
     "node_modules/diff": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
@@ -2815,14 +2806,12 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
-
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
-
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -2837,7 +2826,6 @@
         "node": ">= 0.8"
       }
     },
-
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
@@ -2972,7 +2960,6 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
-
     "node_modules/eslint": {
       "version": "9.33.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.33.0.tgz",
@@ -3196,7 +3183,6 @@
         "node": ">= 0.6"
       }
     },
-
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -3322,7 +3308,6 @@
         "node": ">= 0.6"
       }
     },
-
     "node_modules/fast-copy": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
@@ -3451,7 +3436,6 @@
         "node": ">= 0.8"
       }
     },
-
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3590,7 +3574,6 @@
         "node": ">= 0.8"
       }
     },
-
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3838,7 +3821,6 @@
         "node": ">= 0.8"
       }
     },
-
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -3859,7 +3841,6 @@
         "node": ">=0.10.0"
       }
     },
-
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -3919,7 +3900,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-
     "node_modules/inquirer": {
       "version": "12.9.1",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.9.1.tgz",
@@ -3955,7 +3935,6 @@
         "node": ">= 0.10"
       }
     },
-
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4244,7 +4223,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4264,7 +4242,6 @@
         "node": ">= 0.6"
       }
     },
-
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -4303,7 +4280,6 @@
         "node": ">=4.0.0"
       }
     },
-
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -4382,6 +4358,12 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -4415,7 +4397,6 @@
         "node": ">= 0.6"
       }
     },
-
     "node_modules/node-addon-api": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
@@ -4503,7 +4484,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -4524,7 +4504,6 @@
         "node": ">= 0.8"
       }
     },
-
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4816,7 +4795,6 @@
         "node": ">= 0.8"
       }
     },
-
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4859,7 +4837,6 @@
         "node": ">=16"
       }
     },
-
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -5035,7 +5012,6 @@
         "node": ">= 0.10"
       }
     },
-
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -5074,7 +5050,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5124,7 +5099,6 @@
         "node": ">= 0.8"
       }
     },
-
     "node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
@@ -5290,7 +5264,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5401,7 +5374,6 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
-
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5419,6 +5391,78 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -5479,7 +5523,6 @@
         "node": ">= 0.8"
       }
     },
-
     "node_modules/std-env": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
@@ -5628,7 +5671,6 @@
         "node": ">=14.18.0"
       }
     },
-
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5725,7 +5767,6 @@
         "node": ">=0.6"
       }
     },
-
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -5739,6 +5780,24 @@
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.0"
+      }
+    },
+    "node_modules/tree-sitter-ada": {
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/briot/tree-sitter-ada.git#6b58259a08b1a22ba0247a7ce30be384db618da6",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.1",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.4"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
       }
     },
     "node_modules/tree-sitter-c": {
@@ -5757,6 +5816,16 @@
         "tree_sitter": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tree-sitter-c-sharp": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-c-sharp/-/tree-sitter-c-sharp-0.20.0.tgz",
+      "integrity": "sha512-HOR6fQtghA7hp/LC6fQzzCyRv8TINh/hqYUULYHOYmwsCV73j4PHLYg1536qv/vff1KaRd7Qx3Fs3VLzx1/WIQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "nan": "^2.14.0"
       }
     },
     "node_modules/tree-sitter-cpp": {
@@ -5953,11 +6022,11 @@
         "node": ">= 0.6"
       }
     },
-
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6011,7 +6080,6 @@
         "node": ">= 0.8"
       }
     },
-
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -6047,7 +6115,6 @@
         "node": ">= 0.8"
       }
     },
-
     "node_modules/vectra": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/vectra/-/vectra-0.11.1.tgz",
@@ -6464,7 +6531,6 @@
         }
       }
     },
-
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "tree-sitter-cpp": "^0.21.0",
     "tree-sitter-python": "^0.21.0",
     "tree-sitter-typescript": "^0.21.1",
-    "typescript": "^5.4.5",
+    "typescript": "^5.9.3",
     "vectra": "^0.11.1",
     "ws": "^8.18.0",
     "yargs": "^17.7.2",

--- a/src/ai/providers/mcp.ts
+++ b/src/ai/providers/mcp.ts
@@ -5,7 +5,8 @@
 
 import { AIProvider } from './interface.js';
 import { Logger } from '../../types.js';
-import { Client, StdioClientTransport } from '@modelcontextprotocol/sdk';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { McpConfig } from '../../config/schema.js';
 
 export class McpProvider implements AIProvider {
@@ -68,7 +69,7 @@ export class McpProvider implements AIProvider {
 
       // The resource content is expected to be a stringified JSON array of numbers.
       if (resource.contents.length > 0 && resource.contents[0].text) {
-        return JSON.parse(resource.contents[0].text);
+        return JSON.parse(resource.contents[0].text as string);
       }
       return [];
     } catch (err: any) {

--- a/src/codebase/indexer.ts
+++ b/src/codebase/indexer.ts
@@ -68,6 +68,7 @@ export class Indexer {
     const allFiles = await scanProject(this.projectRoot);
     const files = allFiles.filter(file => VALID_EXTENSIONS.has(path.extname(file).toLowerCase()));
     const cachedFiles = Object.keys(this.cache);
+
     if (files.length !== cachedFiles.length) return false;
     for (const file of files) {
       if (await this.isEntryStale(file)) return false;

--- a/src/core/index-core.ts
+++ b/src/core/index-core.ts
@@ -20,7 +20,7 @@ const MAX_FILE_SIZE_BYTES = 1024 * 1024; // 1MB
 
 export async function runIndex(context: AppContext, onUpdate: AgentCallback) {
   const { logger, aiProvider, args, profile } = context;
-  const projectRoot = profile.cwd;
+  const projectRoot = profile.cwd as string;
   const indexer = await getIndexer(projectRoot);
 
   try {
@@ -80,6 +80,8 @@ export async function runIndex(context: AppContext, onUpdate: AgentCallback) {
         const stats = await fs.stat(file);
         if (stats.size > MAX_FILE_SIZE_BYTES) {
           logger.warn(`Skipping large file: ${file} (${(stats.size / 1024).toFixed(2)} KB)`);
+          await indexer.updateEntry(file, { status: "skipped" });
+          onUpdate({ type: "action", content: "file-processed" });
           continue;
         }
 
@@ -96,6 +98,7 @@ export async function runIndex(context: AppContext, onUpdate: AgentCallback) {
         const errorMessage = `Could not process file ${file}: ${(error as Error).message}`;
         onUpdate({ type: 'error', content: errorMessage });
         failedFiles.push(file);
+        await indexer.updateEntry(file, { status: "failed", error: errorMessage });
       }
     }
 
@@ -120,7 +123,7 @@ export async function runIndex(context: AppContext, onUpdate: AgentCallback) {
 
 export async function runInit(context: AppContext, onUpdate: AgentCallback): Promise<void> {
   const { logger, aiProvider, args, profile } = context;
-  const projectRoot = profile.cwd;
+  const projectRoot = profile.cwd as string;
   
   try {
     onUpdate({ type: 'thought', content: `Initializing project at ${projectRoot}...` });


### PR DESCRIPTION
Fixes the issue where `kinch-code chat` loops endlessly by prompting the user to index the codebase over and over again if some files fail to index or are skipped because of size limits.

---
*PR created automatically by Jules for task [7619443867427048046](https://jules.google.com/task/7619443867427048046) started by @LokiMetaSmith*